### PR TITLE
Fix DRM_FORMAT_A/XRGB8888 swizzle for libgo2.

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -554,7 +554,7 @@ static uint32_t go2_rkformat_get(uint32_t drm_fourcc)
     
         case DRM_FORMAT_ARGB8888:
         case DRM_FORMAT_XRGB8888:
-            return RK_FORMAT_BGRA_8888;
+            return RK_FORMAT_RGBX_8888;
     
         case DRM_FORMAT_RGB565:
             return RK_FORMAT_RGB_565;


### PR DESCRIPTION
Previously this was defined as RK_FORMAT_BGRA_8888, which is the wrong layout for these formats.

This commit fixes wrong color output on certain displays.